### PR TITLE
Build master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ matrix:
   include:
   - services: docker
     env:
+    - SPARK_VERSION=master
+    - HADOOP_VERSION=3.1.0
+    - WITH_HIVE=true
+    - WITH_PYSPARK=true
+  - services: docker
+    env:
     - SPARK_VERSION=2.3.0
     - HADOOP_VERSION=2.7.3
     - WITH_HIVE=true

--- a/make-distribution.sh
+++ b/make-distribution.sh
@@ -32,19 +32,19 @@ pushd spark >/dev/null
 
 # The build is very verbose and exceeds max log length, need to reduce using awk
 ./dev/make-distribution.sh \
-    ${PYSPARK_INSTALL_FLAG} --name spark-${SPARK_VERSION}_hadoop-${HADOOP_VERSION} \
-    -Phadoop-$(echo ${HADOOP_VERSION} | cut -c 1-3) \
-    -Dhadoop.version=${HADOOP_VERSION} \
+    "${PYSPARK_INSTALL_FLAG}" --name "spark-${SPARK_VERSION}_hadoop-${HADOOP_VERSION}" \
+    "-Phadoop-$(echo "${HADOOP_VERSION}" | cut -c 1-3)" \
+    "-Dhadoop.version=${HADOOP_VERSION}" \
     -Pkubernetes \
-    ${HIVE_INSTALL_FLAG} \
+    "${HIVE_INSTALL_FLAG}" \
     -DskipTests | awk 'NR % 10 == 0'
 
 # Replace Hive for Hadoop 3 since Hive 1.2.1 does not officially support Hadoop 3
 # Note docker-image-tool.sh takes the jars from assembly/target/scala-2.*/jars
-if [ "${WITH_HIVE}" = "true" ] && [ "$(echo ${HADOOP_VERSION} | cut -c 1)" = "3" ]; then
+if [ "${WITH_HIVE}" = "true" ] && [ "$(echo "${HADOOP_VERSION}" | cut -c 1)" = "3" ]; then
     JARS_DIR="$(find assembly -type d -name 'scala-2.*')"
-    (cd ${JARS_DIR} && curl -LO ${HIVE_HADOOP3_HIVE_EXEC_URL})
-    (cp ${JARS_DIR}/hive-exec-1.2.1.spark2.jar dist/jars/)
+    (cd "${JARS_DIR}" && curl -LO "${HIVE_HADOOP3_HIVE_EXEC_URL}")
+    (cp "${JARS_DIR}/hive-exec-1.2.1.spark2.jar" dist/jars/)
 fi
 
 GIT_REV="$(git rev-parse HEAD | cut -c 1-7)"
@@ -55,11 +55,11 @@ else
 fi
 
 # There is no way to rename the Docker image, so we simply retag
-./bin/docker-image-tool.sh -r ${DOCKER_REPO} -t ${SPARK_LABEL}_hadoop-${HADOOP_VERSION} build
+./bin/docker-image-tool.sh -r "${DOCKER_REPO}" -t "${SPARK_LABEL}_hadoop-${HADOOP_VERSION}" build
 
 docker tag "${DOCKER_REPO}/spark:${SPARK_LABEL}_hadoop-${HADOOP_VERSION}" "${DOCKER_REPO}:${SPARK_LABEL}_hadoop-${HADOOP_VERSION}"
 
-SPARK_XY_VERSION="$(echo ${SPARK_VERSION} | cut -c 1-3)"
+SPARK_XY_VERSION="$(echo "${SPARK_VERSION}" | cut -c 1-3)"
 if [ "${SPARK_XY_VERSION}" != "2.3" ]; then  # >= 2.4 or master
     docker tag "${DOCKER_REPO}/spark-r:${SPARK_LABEL}_hadoop-${HADOOP_VERSION}" "${DOCKER_REPO}-r:${SPARK_LABEL}_hadoop-${HADOOP_VERSION}"
     docker tag "${DOCKER_REPO}/spark-py:${SPARK_LABEL}_hadoop-${HADOOP_VERSION}" "${DOCKER_REPO}-py:${SPARK_LABEL}_hadoop-${HADOOP_VERSION}"

--- a/make-distribution.sh
+++ b/make-distribution.sh
@@ -40,10 +40,11 @@ pushd spark >/dev/null
     -DskipTests | awk 'NR % 10 == 0'
 
 # Replace Hive for Hadoop 3 since Hive 1.2.1 does not officially support Hadoop 3
-# Note docker-image-tool.sh takes the jars from assembly/target/scala-2.11/jars
+# Note docker-image-tool.sh takes the jars from assembly/target/scala-2.*/jars
 if [ "${WITH_HIVE}" = "true" ] && [ "$(echo ${HADOOP_VERSION} | cut -c 1)" = "3" ]; then
-    (cd assembly/target/scala-2.11/jars && curl -LO ${HIVE_HADOOP3_HIVE_EXEC_URL})
-    (cp assembly/target/scala-2.11/jars/hive-exec-1.2.1.spark2.jar dist/jars/)
+    JARS_DIR="$(find assembly -type d -name 'scala-2.*')"
+    (cd ${JARS_DIR} && curl -LO ${HIVE_HADOOP3_HIVE_EXEC_URL})
+    (cp ${JARS_DIR}/hive-exec-1.2.1.spark2.jar dist/jars/)
 fi
 
 GIT_REV="$(git rev-parse HEAD | cut -c 1-7)"

--- a/make-distribution.sh
+++ b/make-distribution.sh
@@ -49,9 +49,9 @@ fi
 
 GIT_REV="$(git rev-parse HEAD | cut -c 1-7)"
 if [ "${SPARK_VERSION}" = "master" ]; then
-    SPARK_LABEL="${GIT_REV}"
+    SPARK_LABEL="master-${GIT_REV}"
 else
-    SPARK_LABEL="master-${SPARK_VERSION}"
+    SPARK_LABEL="${SPARK_VERSION}"
 fi
 
 # There is no way to rename the Docker image, so we simply retag
@@ -60,7 +60,7 @@ fi
 docker tag "${DOCKER_REPO}/spark:${SPARK_LABEL}_hadoop-${HADOOP_VERSION}" "${DOCKER_REPO}:${SPARK_LABEL}_hadoop-${HADOOP_VERSION}"
 
 SPARK_XY_VERSION="$(echo "${SPARK_VERSION}" | cut -c 1-3)"
-if [ "${SPARK_XY_VERSION}" != "2.3" ]; then  # >= 2.4 or master
+if [ "${SPARK_VERSION}" != "master" ] && [ "${SPARK_XY_VERSION}" != "2.3" ]; then  # >= 2.4
     docker tag "${DOCKER_REPO}/spark-r:${SPARK_LABEL}_hadoop-${HADOOP_VERSION}" "${DOCKER_REPO}-r:${SPARK_LABEL}_hadoop-${HADOOP_VERSION}"
     docker tag "${DOCKER_REPO}/spark-py:${SPARK_LABEL}_hadoop-${HADOOP_VERSION}" "${DOCKER_REPO}-py:${SPARK_LABEL}_hadoop-${HADOOP_VERSION}"
 fi

--- a/push-images.sh
+++ b/push-images.sh
@@ -4,10 +4,21 @@ set -euo pipefail
 DOCKER_REPO=${DOCKER_REPO:-guangie88/spark-k8s}
 docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
 
-docker push "${DOCKER_REPO}:${SPARK_VERSION}_hadoop-${HADOOP_VERSION}"
+pushd spark >/dev/null
+
+GIT_REV="$(git rev-parse HEAD | cut -c 1-7)"
+if [ "${SPARK_VERSION}" = "master" ]; then
+    SPARK_LABEL="${GIT_REV}"
+else
+    SPARK_LABEL="master-${SPARK_VERSION}"
+fi
+
+docker push "${DOCKER_REPO}:${SPARK_LABEL}_hadoop-${HADOOP_VERSION}"
 
 SPARK_XY_VERSION="$(echo ${SPARK_VERSION} | cut -c 1-3)"
-if [ "${SPARK_XY_VERSION}" != "2.3" ]; then # >= 2.4
-    docker push "${DOCKER_REPO}-r:${SPARK_VERSION}_hadoop-${HADOOP_VERSION}"
-    docker push "${DOCKER_REPO}-py:${SPARK_VERSION}_hadoop-${HADOOP_VERSION}"
+if [ "${SPARK_XY_VERSION}" != "2.3" ]; then  # >= 2.4 or master
+    docker push "${DOCKER_REPO}-r:${SPARK_LABEL}_hadoop-${HADOOP_VERSION}"
+    docker push "${DOCKER_REPO}-py:${SPARK_LABEL}_hadoop-${HADOOP_VERSION}"
 fi
+
+popd >/dev/null

--- a/push-images.sh
+++ b/push-images.sh
@@ -8,15 +8,15 @@ pushd spark >/dev/null
 
 GIT_REV="$(git rev-parse HEAD | cut -c 1-7)"
 if [ "${SPARK_VERSION}" = "master" ]; then
-    SPARK_LABEL="${GIT_REV}"
+    SPARK_LABEL="master-${GIT_REV}"
 else
-    SPARK_LABEL="master-${SPARK_VERSION}"
+    SPARK_LABEL="${SPARK_VERSION}"
 fi
 
 docker push "${DOCKER_REPO}:${SPARK_LABEL}_hadoop-${HADOOP_VERSION}"
 
 SPARK_XY_VERSION="$(echo "${SPARK_VERSION}" | cut -c 1-3)"
-if [ "${SPARK_XY_VERSION}" != "2.3" ]; then  # >= 2.4 or master
+if [ "${SPARK_VERSION}" != "master" ] && [ "${SPARK_XY_VERSION}" != "2.3" ]; then  # >= 2.4
     docker push "${DOCKER_REPO}-r:${SPARK_LABEL}_hadoop-${HADOOP_VERSION}"
     docker push "${DOCKER_REPO}-py:${SPARK_LABEL}_hadoop-${HADOOP_VERSION}"
 fi

--- a/push-images.sh
+++ b/push-images.sh
@@ -15,7 +15,7 @@ fi
 
 docker push "${DOCKER_REPO}:${SPARK_LABEL}_hadoop-${HADOOP_VERSION}"
 
-SPARK_XY_VERSION="$(echo ${SPARK_VERSION} | cut -c 1-3)"
+SPARK_XY_VERSION="$(echo "${SPARK_VERSION}" | cut -c 1-3)"
 if [ "${SPARK_XY_VERSION}" != "2.3" ]; then  # >= 2.4 or master
     docker push "${DOCKER_REPO}-r:${SPARK_LABEL}_hadoop-${HADOOP_VERSION}"
     docker push "${DOCKER_REPO}-py:${SPARK_LABEL}_hadoop-${HADOOP_VERSION}"

--- a/templates/vars.yml
+++ b/templates/vars.yml
@@ -1,4 +1,9 @@
 versions:
+- spark: "master"
+  hadoop: 3.1.0
+  with_hive: "true"
+  with_pyspark: "true"
+
 - spark:  2.3.0
   hadoop: 2.7.3
   with_hive: "true"


### PR DESCRIPTION
Spark on K8s is still improving very quickly, so having commit on `master` branch builds can be useful.