### PR TITLE
Add pyspark content into 2.4 build

### DIFF
--- a/Dockerfile-py
+++ b/Dockerfile-py
@@ -1,7 +1,7 @@
 # This Dockerfile is meant to be only used by make-distribution.sh for copying
 # pyspark directory for >= Spark 2.4
-ARG IMAGE_MAME=
-ARG TAG_MAME=
+ARG IMAGE_MAME
+ARG TAG_MAME
 FROM ${IMAGE_NAME}-py:${TAG_NAME}
 
-COPY ./python/pyspark "${SPARK_HOME}/python/pyspark"
+COPY ./spark/python/pyspark "${SPARK_HOME}/python/pyspark"

--- a/Dockerfile-py
+++ b/Dockerfile-py
@@ -1,7 +1,7 @@
 # This Dockerfile is meant to be only used by make-distribution.sh for copying
 # pyspark directory for >= Spark 2.4
-ARG IMAGE_MAME
-ARG TAG_MAME
+ARG IMAGE_NAME
+ARG TAG_NAME
 FROM ${IMAGE_NAME}-py:${TAG_NAME}
 
 COPY ./spark/python/pyspark "${SPARK_HOME}/python/pyspark"

--- a/Dockerfile-py
+++ b/Dockerfile-py
@@ -1,0 +1,7 @@
+# This Dockerfile is meant to be only used by make-distribution.sh for copying
+# pyspark directory for >= Spark 2.4
+ARG IMAGE_MAME=
+ARG TAG_MAME=
+FROM ${IMAGE_NAME}-py:${TAG_NAME}
+
+COPY ./spark/python/pyspark "${SPARK_HOME}/python/pyspark"

--- a/Dockerfile-py
+++ b/Dockerfile-py
@@ -4,4 +4,4 @@ ARG IMAGE_MAME=
 ARG TAG_MAME=
 FROM ${IMAGE_NAME}-py:${TAG_NAME}
 
-COPY ./spark/python/pyspark "${SPARK_HOME}/python/pyspark"
+COPY ./python/pyspark "${SPARK_HOME}/python/pyspark"

--- a/make-distribution.sh
+++ b/make-distribution.sh
@@ -90,12 +90,12 @@ if [[ "${SPARK_VERSION}" == "master" ]] || [[ ${SPARK_MAJOR_VERSION} -ge 3 ]] ||
     docker tag "${IMAGE_NAME}/spark-py:${TAG_NAME}" "${IMAGE_NAME}-py:${TAG_NAME}"
 fi
 
+popd >/dev/null
+
 # Spark 2.4 builds are silly and don't include spark/python/pyspark contents
 # So manually include them
 if [[ ${SPARK_MAJOR_VERSION} -eq 2 && ${SPARK_MINOR_VERSION} -ge 4 ]]; then  # >= 2.4
-    docker build . -t "${IMAGE_NAME}-py:${TAG_NAME}" \
-        --build-arg "IMAGE_MAME=${IMAGE_MAME}" \
-        --build-arg "TAG_MAME=${TAG_MAME}"
+    docker build . -f Dockerfile-py -t "${IMAGE_NAME}-py:${TAG_NAME}" \
+        --build-arg "IMAGE_NAME=${IMAGE_NAME}" \
+        --build-arg "TAG_NAME=${TAG_NAME}"
 fi
-
-popd >/dev/null

--- a/make-distribution.sh
+++ b/make-distribution.sh
@@ -94,7 +94,7 @@ popd >/dev/null
 
 # Spark 2.4 builds are silly and don't include spark/python/pyspark contents
 # So manually include them
-if [[ ${SPARK_MAJOR_VERSION} -eq 2 && ${SPARK_MINOR_VERSION} -ge 4 ]]; then  # >= 2.4
+if [[ "${SPARK_VERSION}" != "master" ]] && [[ ${SPARK_MAJOR_VERSION} -eq 2 && ${SPARK_MINOR_VERSION} -ge 4 ]]; then  # >= 2.4
     docker build . -f Dockerfile-py -t "${IMAGE_NAME}-py:${TAG_NAME}" \
         --build-arg "IMAGE_NAME=${IMAGE_NAME}" \
         --build-arg "TAG_NAME=${TAG_NAME}"

--- a/make-distribution.sh
+++ b/make-distribution.sh
@@ -85,9 +85,17 @@ SPARK_MINOR_VERSION="$(echo "${SPARK_VERSION}" | cut -d '.' -f2)"
 
 # There is no way to rename the Docker image, so we simply retag
 # Spark <= 2.3 does not do -py and -r set-up, therefore we need this check here
-if [[ "${SPARK_VERSION}" == "master" ]] || [[ ${SPARK_MAJOR_VERSION} -ge 2 && ${SPARK_MINOR_VERSION} -ge 4 ]]; then  # >= 2.4
+if [[ "${SPARK_VERSION}" == "master" ]] || [[ ${SPARK_MAJOR_VERSION} -ge 3 ]] || [[ ${SPARK_MAJOR_VERSION} -eq 2 && ${SPARK_MINOR_VERSION} -ge 4 ]]; then  # >= 2.4
     docker tag "${IMAGE_NAME}/spark-r:${TAG_NAME}" "${IMAGE_NAME}-r:${TAG_NAME}"
     docker tag "${IMAGE_NAME}/spark-py:${TAG_NAME}" "${IMAGE_NAME}-py:${TAG_NAME}"
+fi
+
+# Spark 2.4 builds are silly and don't include spark/python/pyspark contents
+# So manually include them
+if [[ ${SPARK_MAJOR_VERSION} -eq 2 && ${SPARK_MINOR_VERSION} -ge 4 ]]; then  # >= 2.4
+    docker build . -t "${IMAGE_NAME}-py:${TAG_NAME}" \
+        --build-arg "IMAGE_MAME=${IMAGE_MAME}" \
+        --build-arg "TAG_MAME=${TAG_MAME}"
 fi
 
 popd >/dev/null


### PR DESCRIPTION
So that spark-k8s-py for Spark >= 2.4 can run `pyspark` properly.