### PR TITLE
Switch to openjdk due to failing builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: java
 
 jdk:
-- oraclejdk8
+- openjdk8
+
+dist: xenial
 
 sudo: required
 

--- a/templates/.travis.yml.tmpl
+++ b/templates/.travis.yml.tmpl
@@ -1,7 +1,9 @@
 language: java
 
 jdk:
-- oraclejdk8
+- openjdk8
+
+dist: xenial
 
 sudo: required
 


### PR DESCRIPTION
Keep getting error in Travis:

```bash
Installing oraclejdk8

$ export JAVA_HOME=~/oraclejdk8

$ export PATH="$JAVA_HOME/bin:$PATH"

$ ~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"

Ignoring license option: BCL -- using GPLv2+CE by default

install-jdk.sh 2019-09-17

Expected feature release number in range of 9 to 14, but got: 8

The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .
```