### PR TITLE
fix(setup): missing pyspark for Spark 2.4.z

### DIFF
--- a/Dockerfile-py
+++ b/Dockerfile-py
@@ -1,0 +1,7 @@
+# This Dockerfile is meant to be only used by make-distribution.sh for copying
+# pyspark directory for >= Spark 2.4
+ARG IMAGE_NAME
+ARG TAG_NAME
+FROM ${IMAGE_NAME}-py:${TAG_NAME}
+
+COPY ./spark/python/pyspark "${SPARK_HOME}/python/pyspark"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ uses `openjdk:8-jdk-slim` as the base image for Kubernetes build.
 Because of the fast-changing nature of the Spark repository, this set-up might
 contain inevitable breaking changes. As such, the build Docker images are
 additionally tagged with this repository distribution tag version as prefix,
-such as `v1_spark-2.4.4_hadoop-3.1.0`.
+such as `v2_2.4.5_hadoop-3.1.0_scala-2.12`.
 
 The older distribution tag version will separately go into a different Git
 branch for clarity.

--- a/make-distribution.sh
+++ b/make-distribution.sh
@@ -66,3 +66,14 @@ docker tag "${IMAGE_NAME}/spark-py:${TAG_NAME}" "${IMAGE_NAME}-py:${TAG_NAME}"
 docker tag "${IMAGE_NAME}/spark-r:${TAG_NAME}" "${IMAGE_NAME}-r:${TAG_NAME}"
 
 popd >/dev/null
+
+# Spark 2.4 builds are silly and don't include spark/python/pyspark contents
+# So manually include them
+SPARK_MAJOR_VERSION="$(echo "${SPARK_VERSION}" | cut -d '.' -f1)"
+SPARK_MINOR_VERSION="$(echo "${SPARK_VERSION}" | cut -d '.' -f2)"
+
+if [[ "${SPARK_VERSION}" != "master" ]] && [[ ${SPARK_MAJOR_VERSION} -eq 2 && ${SPARK_MINOR_VERSION} -ge 4 ]]; then  # >= 2.4
+    docker build . -f Dockerfile-py -t "${IMAGE_NAME}-py:${TAG_NAME}" \
+        --build-arg "IMAGE_NAME=${IMAGE_NAME}" \
+        --build-arg "TAG_NAME=${TAG_NAME}"
+fi


### PR DESCRIPTION
Spark 2.4.z does not include `python/pyspark` in its set-up, so need to
manually inject in.

This was a regression because `v1` supported this.