### PR TITLE
fix(ci): allow different image org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,4 +101,5 @@ jobs:
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        IMAGE_ORG: ${{ secrets.IMAGE_ORG }}
       if: github.event_name == 'push'

--- a/push-images.sh
+++ b/push-images.sh
@@ -3,8 +3,6 @@ set -euo pipefail
 
 echo "${DOCKER_PASSWORD}" | docker login -u="${DOCKER_USERNAME}" --password-stdin
 
-pushd spark >/dev/null
-
 GIT_REV="$(git rev-parse HEAD | cut -c 1-7)"
 if [ "${SPARK_VERSION}" = "master" ]; then
     SPARK_LABEL="master-${GIT_REV}"
@@ -15,21 +13,19 @@ fi
 TAG_NAME="${SELF_VERSION}_${SPARK_LABEL}_hadoop-${HADOOP_VERSION}_scala-${SCALA_VERSION}"
 ALT_TAG_NAME="${SPARK_LABEL}_hadoop-${HADOOP_VERSION}_scala-${SCALA_VERSION}"
 
-docker tag "${IMAGE_NAME}:${TAG_NAME}" "${DOCKER_USERNAME}/${IMAGE_NAME}:${TAG_NAME}"
-docker push "${DOCKER_USERNAME}/${IMAGE_NAME}:${TAG_NAME}"
-docker tag "${IMAGE_NAME}:${TAG_NAME}" "${DOCKER_USERNAME}/${IMAGE_NAME}:${ALT_TAG_NAME}"
-docker push "${DOCKER_USERNAME}/${IMAGE_NAME}:${ALT_TAG_NAME}"
+docker tag "${IMAGE_NAME}:${TAG_NAME}" "${IMAGE_ORG}/${IMAGE_NAME}:${TAG_NAME}"
+docker push "${IMAGE_ORG}/${IMAGE_NAME}:${TAG_NAME}"
+docker tag "${IMAGE_NAME}:${TAG_NAME}" "${IMAGE_ORG}/${IMAGE_NAME}:${ALT_TAG_NAME}"
+docker push "${IMAGE_ORG}/${IMAGE_NAME}:${ALT_TAG_NAME}"
 
 # Python image push
-docker tag "${IMAGE_NAME}-py:${TAG_NAME}" "${DOCKER_USERNAME}/${IMAGE_NAME}-py:${TAG_NAME}"
-docker push "${DOCKER_USERNAME}/${IMAGE_NAME}-py:${TAG_NAME}"
-docker tag "${IMAGE_NAME}-py:${TAG_NAME}" "${DOCKER_USERNAME}/${IMAGE_NAME}-py:${ALT_TAG_NAME}"
-docker push "${DOCKER_USERNAME}/${IMAGE_NAME}-py:${ALT_TAG_NAME}"
+docker tag "${IMAGE_NAME}-py:${TAG_NAME}" "${IMAGE_ORG}/${IMAGE_NAME}-py:${TAG_NAME}"
+docker push "${IMAGE_ORG}/${IMAGE_NAME}-py:${TAG_NAME}"
+docker tag "${IMAGE_NAME}-py:${TAG_NAME}" "${IMAGE_ORG}/${IMAGE_NAME}-py:${ALT_TAG_NAME}"
+docker push "${IMAGE_ORG}/${IMAGE_NAME}-py:${ALT_TAG_NAME}"
 
 # R image push
-docker tag "${IMAGE_NAME}-r:${TAG_NAME}" "${DOCKER_USERNAME}/${IMAGE_NAME}-r:${TAG_NAME}"
-docker push "${DOCKER_USERNAME}/${IMAGE_NAME}-r:${TAG_NAME}"
-docker tag "${IMAGE_NAME}-r:${TAG_NAME}" "${DOCKER_USERNAME}/${IMAGE_NAME}-r:${ALT_TAG_NAME}"
-docker push "${DOCKER_USERNAME}/${IMAGE_NAME}-r:${ALT_TAG_NAME}"
-
-popd >/dev/null
+docker tag "${IMAGE_NAME}-r:${TAG_NAME}" "${IMAGE_ORG}/${IMAGE_NAME}-r:${TAG_NAME}"
+docker push "${IMAGE_ORG}/${IMAGE_NAME}-r:${TAG_NAME}"
+docker tag "${IMAGE_NAME}-r:${TAG_NAME}" "${IMAGE_ORG}/${IMAGE_NAME}-r:${ALT_TAG_NAME}"
+docker push "${IMAGE_ORG}/${IMAGE_NAME}-r:${ALT_TAG_NAME}"

--- a/templates/ci.yml.tmpl
+++ b/templates/ci.yml.tmpl
@@ -67,5 +67,6 @@ jobs:
         {% raw -%}
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        IMAGE_ORG: ${{ secrets.IMAGE_ORG }}
         {%- endraw %}
       if: github.event_name == 'push'


### PR DESCRIPTION
Differentiates image org from login docker username since the username
might just be a team member / collab of the org to push into.